### PR TITLE
Log's timestamp does not match in Java 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+##1.5.2-tableau-003
+* Fix log timestamp not match issue with Java 11
+
 ##1.5.2-tableau-002
 * Fix bug which deletes incorrect edges when flushing cached edges to remove
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.umlg</groupId>
     <artifactId>sqlg</artifactId>
     <packaging>pom</packaging>
-    <version>1.5.2-tableau-002</version>
+    <version>1.5.2-tableau-003</version>
     <name>sqlg</name>
     <description>Sqlg is a tinkerpop 3 implementation on top of a rdbms.
     </description>
@@ -31,7 +31,7 @@
         <url>git@github.com:pietermartin/sqlg.git</url>
     </scm>
     <properties>
-        <sqlg.version>1.5.2-tableau-002</sqlg.version>
+        <sqlg.version>1.5.2-tableau-003</sqlg.version>
         <tinkerpop.version>3.3.3</tinkerpop.version>
         <slf4j.version>1.7.21</slf4j.version>
         <junit.version>4.12</junit.version>

--- a/sqlg-benchmark-h2/pom.xml
+++ b/sqlg-benchmark-h2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-benchmark-h2</artifactId>
     <name>sqlg :: benchmark-h2</name>

--- a/sqlg-benchmark-hsqldb/pom.xml
+++ b/sqlg-benchmark-hsqldb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-benchmark-hsqldb</artifactId>
     <name>sqlg :: benchmark-hsqldb</name>

--- a/sqlg-benchmark-postgres/pom.xml
+++ b/sqlg-benchmark-postgres/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.umlg</groupId>
 		<artifactId>sqlg</artifactId>
-		<version>1.5.2-tableau-002</version>
+		<version>1.5.2-tableau-003</version>
 	</parent>
 	<artifactId>sqlg-benchmark-postgres</artifactId>
 	<name>sqlg :: benchmark-postgres</name>

--- a/sqlg-benchmark/pom.xml
+++ b/sqlg-benchmark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-benchmark</artifactId>
     <name>sqlg :: benchmark</name>

--- a/sqlg-cockroachdb-parent/pom.xml
+++ b/sqlg-cockroachdb-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sqlg</artifactId>
         <groupId>org.umlg</groupId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sqlg-cockroachdb-parent/sqlg-cockroachdb-dialect/pom.xml
+++ b/sqlg-cockroachdb-parent/sqlg-cockroachdb-dialect/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg-cockroachdb-parent</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-cockroachdb-dialect</artifactId>
     <name>sqlg :: cockroachdb dialect</name>

--- a/sqlg-cockroachdb-parent/sqlg-cockroachdb/pom.xml
+++ b/sqlg-cockroachdb-parent/sqlg-cockroachdb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg-cockroachdb-parent</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-cockroachdb</artifactId>
     <name>sqlg :: cockroachdb</name>

--- a/sqlg-core/pom.xml
+++ b/sqlg-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.umlg</groupId>
 		<artifactId>sqlg</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
 	</parent>
 	<artifactId>sqlg-core</artifactId>
 	<name>sqlg :: core</name>

--- a/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/Topology.java
+++ b/sqlg-core/src/main/java/org/umlg/sqlg/structure/topology/Topology.java
@@ -19,6 +19,7 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -1071,7 +1072,7 @@ public class Topology {
                         .toList();
                 Preconditions.checkState(logs.size() == 1, "There must be one and only be one log, found %d", logs.size());
                 LocalDateTime timestamp = logs.get(0).value("timestamp");
-                Preconditions.checkState(timestamp.equals(notifyTimestamp), "notify log's timestamp does not match.");
+                Preconditions.checkState(Duration.between(notifyTimestamp, timestamp).toMillis() < 1, "notify log's timestamp does not match.");
                 int backEndPid = logs.get(0).value("pid");
                 Preconditions.checkState(backEndPid == pid, "notify pids do not match.");
                 ObjectNode log = logs.get(0).value("log");

--- a/sqlg-h2-parent/pom.xml
+++ b/sqlg-h2-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sqlg</artifactId>
         <groupId>org.umlg</groupId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sqlg-h2-parent/sqlg-h2-dialect/pom.xml
+++ b/sqlg-h2-parent/sqlg-h2-dialect/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sqlg-h2-parent</artifactId>
         <groupId>org.umlg</groupId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sqlg-h2-parent/sqlg-h2/pom.xml
+++ b/sqlg-h2-parent/sqlg-h2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sqlg-h2-parent</artifactId>
         <groupId>org.umlg</groupId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sqlg-hsqldb-parent/pom.xml
+++ b/sqlg-hsqldb-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sqlg</artifactId>
         <groupId>org.umlg</groupId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sqlg-hsqldb-parent/sqlg-hsqldb-dialect/pom.xml
+++ b/sqlg-hsqldb-parent/sqlg-hsqldb-dialect/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg-hsqldb-parent</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-hsqldb-dialect</artifactId>
     <name>sqlg :: hsqldb dialect</name>

--- a/sqlg-hsqldb-parent/sqlg-hsqldb/pom.xml
+++ b/sqlg-hsqldb-parent/sqlg-hsqldb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg-hsqldb-parent</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-hsqldb</artifactId>
     <name>sqlg :: hsqldb</name>

--- a/sqlg-mariadb-parent/pom.xml
+++ b/sqlg-mariadb-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sqlg</artifactId>
         <groupId>org.umlg</groupId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sqlg-mariadb-parent/sqlg-mariadb-dialect/pom.xml
+++ b/sqlg-mariadb-parent/sqlg-mariadb-dialect/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg-mariadb-parent</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-mariadb-dialect</artifactId>
     <name>sqlg :: mariadb dialect</name>

--- a/sqlg-mariadb-parent/sqlg-mariadb/pom.xml
+++ b/sqlg-mariadb-parent/sqlg-mariadb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg-mariadb-parent</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-mariadb</artifactId>
     <name>sqlg :: mariadb</name>

--- a/sqlg-mssqlserver-parent/pom.xml
+++ b/sqlg-mssqlserver-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sqlg</artifactId>
         <groupId>org.umlg</groupId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sqlg-mssqlserver-parent/sqlg-mssqlserver-dialect/pom.xml
+++ b/sqlg-mssqlserver-parent/sqlg-mssqlserver-dialect/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sqlg-mssqlserver-parent</artifactId>
         <groupId>org.umlg</groupId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sqlg-mssqlserver-parent/sqlg-mssqlserver/pom.xml
+++ b/sqlg-mssqlserver-parent/sqlg-mssqlserver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sqlg-mssqlserver-parent</artifactId>
         <groupId>org.umlg</groupId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sqlg-mysql-parent/pom.xml
+++ b/sqlg-mysql-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sqlg</artifactId>
         <groupId>org.umlg</groupId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sqlg-mysql-parent/sqlg-mysql-dialect/pom.xml
+++ b/sqlg-mysql-parent/sqlg-mysql-dialect/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg-mysql-parent</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-mysql-dialect</artifactId>
     <name>sqlg :: mysql dialect</name>

--- a/sqlg-mysql-parent/sqlg-mysql/pom.xml
+++ b/sqlg-mysql-parent/sqlg-mysql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg-mysql-parent</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-mysql</artifactId>
     <name>sqlg :: mysql</name>

--- a/sqlg-postgres-parent/pom.xml
+++ b/sqlg-postgres-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sqlg</artifactId>
         <groupId>org.umlg</groupId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sqlg-postgres-parent/sqlg-postgres-dialect/pom.xml
+++ b/sqlg-postgres-parent/sqlg-postgres-dialect/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg-postgres-parent</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-postgres-dialect</artifactId>
     <name>sqlg :: postgres dialect</name>

--- a/sqlg-postgres-parent/sqlg-postgres/pom.xml
+++ b/sqlg-postgres-parent/sqlg-postgres/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg-postgres-parent</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-postgres</artifactId>
     <name>sqlg :: postgres</name>

--- a/sqlg-test/pom.xml
+++ b/sqlg-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.umlg</groupId>
         <artifactId>sqlg</artifactId>
-        <version>1.5.2-tableau-002</version>
+        <version>1.5.2-tableau-003</version>
     </parent>
     <artifactId>sqlg-test</artifactId>
     <name>sqlg :: test</name>

--- a/start-test-postgres.sh
+++ b/start-test-postgres.sh
@@ -2,4 +2,4 @@
 
 docker build --tag=sqlg-postgres ./sqlg-testdb-postgres
 
-docker run --rm -d --name sqlg-postgres -p 5432:5432 sqlg-postgres
+docker run --rm -d --name sqlg-postgres -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust sqlg-postgres


### PR DESCRIPTION
This fixes a timestamp comparison issue in Topology.java with Java 11. We will validate the diff with mill sec precision.

Refers to https://github.com/pietermartin/sqlg/commit/c138e2f5cf3af4c7c55ebd648877678851e75527 for similar fix.